### PR TITLE
feat: support item generics

### DIFF
--- a/partial_eq_dyn_derive/src/as_any_derive.rs
+++ b/partial_eq_dyn_derive/src/as_any_derive.rs
@@ -8,8 +8,9 @@ pub fn parse(input: TokenStream) -> DeriveInput {
 
 pub fn impl_as_any(ast: &syn::DeriveInput) -> TokenStream {
     let item_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     quote! {
-        impl  partial_eq_dyn::AsAny for #item_name {
+        impl #impl_generics partial_eq_dyn::AsAny for #item_name #ty_generics #where_clause {
             fn as_any(&self) -> &dyn std::any::Any {
                 self
             }

--- a/partial_eq_dyn_derive/src/dyn_partial_eq_derive.rs
+++ b/partial_eq_dyn_derive/src/dyn_partial_eq_derive.rs
@@ -8,8 +8,9 @@ pub fn parse(input: TokenStream) -> DeriveInput {
 
 pub fn impl_dyn_partial_eq(ast: &syn::DeriveInput) -> TokenStream {
     let item_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     quote! {
-        impl partial_eq_dyn::DynPartialEq for #item_name {
+        impl #impl_generics partial_eq_dyn::DynPartialEq for #item_name #ty_generics #where_clause {
             fn dyn_eq(&self, other: &dyn std::any::Any) -> bool {
                 other
                     .downcast_ref::<#item_name>()

--- a/partial_eq_dyn_derive/src/partial_eq_dyn_derive.rs
+++ b/partial_eq_dyn_derive/src/partial_eq_dyn_derive.rs
@@ -16,6 +16,7 @@ pub fn parse(input: TokenStream) -> DeriveInput {
 pub fn impl_partial_eq_dyn(ast: &syn::DeriveInput) -> TokenStream {
     let item_ident = &ast.ident;
     let item_data = &ast.data;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let gen_field_comps = match item_data {
         syn::Data::Struct(data) => gen_part_eq_struct_data(data),
         syn::Data::Enum(data) => gen_part_eq_enum_data(data),
@@ -25,7 +26,7 @@ pub fn impl_partial_eq_dyn(ast: &syn::DeriveInput) -> TokenStream {
             ),
     };
     let gen_part_eq = quote! {
-        impl PartialEq for #item_ident {
+        impl #impl_generics PartialEq for #item_ident #ty_generics #where_clause {
             fn eq(&self, other: &Self) -> bool {
                 #gen_field_comps
             }


### PR DESCRIPTION
`partial_eq_dyn_derive` is really great, expect that it does not support generics. 😄

This PR add generics support for all the three derive macros. 

